### PR TITLE
Update Robinhood jobs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Please note that it is not encouraged to blindly apply to every company on this 
 | [RetailNext](http://retailnext.net/about-us/career-openings/) | Chicago, IL; San Francisco, CA; San Jose, CA |
 | [Riot Games](http://www.riotgames.com/careers) | Los Angeles, CA |
 | [RiskIQ](https://www.riskiq.com/careers) | San Francisco, CA |
-| [Robinhood](https://jobs.lever.co/robinhood) | Palo Alto, CA |
+| [Robinhood](https://robinhood.com/jobs) | Palo Alto, CA |
 | [ROBLOX](http://corp.roblox.com/careers) | San Mateo, CA |
 | [Roku](https://www.roku.com/about/jobs) | Austin, TX; Los Gatos, CA |
 | [Rover.com](http://jobs.rover.com/) | Seattle, WA |


### PR DESCRIPTION
The Robinhood jobs page has changed - this is the canonical url.